### PR TITLE
Switch to specific group when searching for TAGs

### DIFF
--- a/ome_data/tags_data.py
+++ b/ome_data/tags_data.py
@@ -1,6 +1,8 @@
 import omero
 from omero.gateway import TagAnnotationWrapper
 
+from utils import switch_to_default_search_group
+
 
 def _is_tagset(obj):
     try:
@@ -42,6 +44,7 @@ def _image_to_json(image_object):
 
 
 def _get_images_by_tag(tag_id, connection):
+    switch_to_default_search_group(connection)
     imgs_generator = connection.getObjectsByAnnotations('Image', [tag_id])
     images = list()
     for img in imgs_generator:
@@ -50,6 +53,7 @@ def _get_images_by_tag(tag_id, connection):
 
 
 def get_annotations_list(connection, fetch_images=False):
+    switch_to_default_search_group(connection)
     tag_sets = list()
     tags = list()
     for t in connection.getObjects("TagAnnotation"):
@@ -77,6 +81,7 @@ def get_annotations_list(connection, fetch_images=False):
 
 
 def get_tags_list(tagset_id, connection, fetch_images=False, append_raw_object=False):
+    switch_to_default_search_group(connection)
     tags = list()
     tagset = connection.getObject('TagAnnotation', tagset_id)
     if tagset is None:
@@ -97,6 +102,7 @@ def get_images(tag_id, connection):
 
 
 def find_annotations(search_pattern, connection, fetch_images=False):
+    switch_to_default_search_group(connection)
     query_service = connection.getQueryService()
     query_params = omero.sys.ParametersI()
     query_params.addString('search_pattern', '%%%s%%' % search_pattern)

--- a/ome_data/utils.py
+++ b/ome_data/utils.py
@@ -1,0 +1,20 @@
+from ome_seadragon import settings
+
+
+def _get_group_id_by_name(group_name, connection):
+    group = connection.getObject('ExperimenterGroup', attributes={'name': group_name})
+    if group:
+        return group.id
+    else:
+        return None
+
+
+def _get_current_group_id(connection):
+    return connection.getGroupFromContext().id
+
+
+def switch_to_default_search_group(connection):
+    if settings.DEFAULT_SEARCH_GROUP:
+        group_id = _get_group_id_by_name(settings.DEFAULT_SEARCH_GROUP, connection)
+        if group_id and (group_id != _get_current_group_id(connection)):
+            connection.setGroupForSession(group_id)

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,7 @@
+def identity(value):
+    return value
+
+
+CUSTOM_SETTINGS_MAPPINGS = {
+    'omero.web.ome_seadragon.search.default_group': ['DEFAULT_SEARCH_GROUP', None, identity, None]
+}


### PR DESCRIPTION
Set a default group to use when searching for TAGs, useful if OMERO public user's default group is different from the one that contains the TAGs we want to search.